### PR TITLE
Fix: Drop extra digit from 12 hour formatting

### DIFF
--- a/src/formatTimeOfDay.ts
+++ b/src/formatTimeOfDay.ts
@@ -25,7 +25,7 @@ export function formatTimeOfDay (
   }: FormatTimeOfDayOptions = {},
 ): string {
   const formatOptions: Record<string, string> = {
-    '12h': 'hh:mm a',
+    '12h': 'h:mm a',
     '24h': 'HH:mm',
   }
 

--- a/src/formatTimeOfDay.ts
+++ b/src/formatTimeOfDay.ts
@@ -3,7 +3,7 @@ import { tz } from '@date-fns/tz'
 
 type FormatTimeOfDayOptions = {
   timezone?: string
-  format?: '12h' | '24h'
+  format?: '12hNoAmPm' | '12h' | '24h'
   seconds?: 'always' | 'nonzero' | 'never'
 }
 
@@ -25,11 +25,12 @@ export function formatTimeOfDay (
   }: FormatTimeOfDayOptions = {},
 ): string {
   const formatOptions: Record<string, string> = {
-    '12h': 'h:mm a',
-    '24h': 'HH:mm',
+    '12hNoAmPm': 'h:mm', // -> 1:20
+    '12h': 'h:mm a', // -> 1:20 PM
+    '24h': 'HH:mm', // -> 13:00
   }
 
-  let timeFormat = formatOptions[format]
+  let timeFormat = format ? formatOptions[format] : formatOptions['24h']
 
   // Append seconds to the format string based on the seconds option
   if (seconds === 'always' || (seconds === 'nonzero' && getSeconds(date) !== 0)) {

--- a/tests/formatTimeOfDay.test.js
+++ b/tests/formatTimeOfDay.test.js
@@ -73,11 +73,13 @@ describe('formatTimeOfDay', () => {
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always', timezone: 'America/Los_Angeles' })
     expect(formatted).to.equal('8:10:30 AM')
   })
+
   it('should format time in 12h (with no AM/PM) format in America/Los_Angeles timezone', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12hNoAmPm', seconds: 'always', timezone: 'America/Los_Angeles' })
     expect(formatted).to.equal('8:10:30')
   })
+
   it('should format time in 24h if "format" is an empty string', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '', seconds: 'always', timezone: 'America/Los_Angeles' })

--- a/tests/formatTimeOfDay.test.js
+++ b/tests/formatTimeOfDay.test.js
@@ -73,6 +73,16 @@ describe('formatTimeOfDay', () => {
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always', timezone: 'America/Los_Angeles' })
     expect(formatted).to.equal('8:10:30 AM')
   })
+  it('should format time in 12h (with no AM/PM) format in America/Los_Angeles timezone', () => {
+    const date = new Date('2023-06-17T15:10:30Z')
+    const formatted = formatTimeOfDay(date, { format: '12hNoAmPm', seconds: 'always', timezone: 'America/Los_Angeles' })
+    expect(formatted).to.equal('8:10:30')
+  })
+  it('should format time in 24h if "format" is an empty string', () => {
+    const date = new Date('2023-06-17T15:10:30Z')
+    const formatted = formatTimeOfDay(date, { format: '', seconds: 'always', timezone: 'America/Los_Angeles' })
+    expect(formatted).to.equal('08:10:30')
+  })
 
   // Tests for `seconds = 'never'`
   it('should format time in 24h format without seconds', () => {

--- a/tests/formatTimeOfDay.test.js
+++ b/tests/formatTimeOfDay.test.js
@@ -23,19 +23,19 @@ describe('formatTimeOfDay', () => {
   it('should format time in 12h format with seconds always shown', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always' })
-    expect(formatted).to.equal('03:10:30 PM')
+    expect(formatted).to.equal('3:10:30 PM')
   })
 
   it('should format time in 12h format with nonzero seconds shown', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'nonzero' })
-    expect(formatted).to.equal('03:10:30 PM')
+    expect(formatted).to.equal('3:10:30 PM')
   })
 
   it('should format time in 12h format with zero seconds hidden', () => {
     const date = new Date('2023-06-17T15:10:00Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'nonzero' })
-    expect(formatted).to.equal('03:10 PM')
+    expect(formatted).to.equal('3:10 PM')
   })
 
   it('should format time in 24h format in Europe/Berlin timezone', () => {
@@ -47,7 +47,7 @@ describe('formatTimeOfDay', () => {
   it('should format time in 12h format in Europe/Berlin timezone', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always', timezone: 'Europe/Berlin' })
-    expect(formatted).to.equal('05:10:30 PM')
+    expect(formatted).to.equal('5:10:30 PM')
   })
 
   it('should format time in 24h format in Australia/Sydney timezone', () => {
@@ -59,7 +59,7 @@ describe('formatTimeOfDay', () => {
   it('should format time in 12h format in Australia/Sydney timezone', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always', timezone: 'Australia/Sydney' })
-    expect(formatted).to.equal('01:10:30 AM')
+    expect(formatted).to.equal('1:10:30 AM')
   })
 
   it('should format time in 24h format in America/Los_Angeles timezone', () => {
@@ -71,7 +71,7 @@ describe('formatTimeOfDay', () => {
   it('should format time in 12h format in America/Los_Angeles timezone', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'always', timezone: 'America/Los_Angeles' })
-    expect(formatted).to.equal('08:10:30 AM')
+    expect(formatted).to.equal('8:10:30 AM')
   })
 
   // Tests for `seconds = 'never'`
@@ -84,7 +84,7 @@ describe('formatTimeOfDay', () => {
   it('should format time in 12h format without seconds', () => {
     const date = new Date('2023-06-17T15:10:30Z')
     const formatted = formatTimeOfDay(date, { format: '12h', seconds: 'never' })
-    expect(formatted).to.equal('03:10 PM')
+    expect(formatted).to.equal('3:10 PM')
   })
 
   // Tests for passing no options object


### PR DESCRIPTION
- Remove first 0 from 12h ~~01:00 PM~~ -> 1:00 PM
- Force 24h if incoming string is empty
- Add a 12h without AM/PM

https://simple.wikipedia.org/wiki/12-hour_clock