### PR TITLE
Fix: Must set year, month, day atomically to avoid month overflow 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1352,7 +1352,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -1651,7 +1650,6 @@
       "integrity": "sha512-HtXZ7Ki3LoZe8zYzrqvTWB+MWvB42TMkpm60E50vgDZp/+TQgCG55uXMS/vD5PJCMI5zWTNFWIlAVD03e6l5hw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.1",
         "fflate": "^0.8.2",
@@ -1688,7 +1686,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2004,7 +2001,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2058,7 +2054,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3087,7 +3082,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3710,7 +3704,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3749,14 +3742,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3773,7 +3758,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3849,7 +3833,6 @@
       "integrity": "sha512-4rwTfUNF0MExMZBiNirkzZpeyUZGOs3JD76N2qHNP9i6w6/bff7MRv2I9yFJKd1ICxzn2igpra+E4t9o2EfQhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.1",
         "@vitest/mocker": "4.0.1",

--- a/src/applyDate.ts
+++ b/src/applyDate.ts
@@ -39,8 +39,9 @@ export function applyDate (
   outputInZone.setUTCFullYear(dateInZone.getUTCFullYear(), dateInZone.getUTCMonth(), dateInZone.getUTCDate())
 
   // Change output from specified timezone back to UTC
-  // Note: We guess that the dateOffset is likely identical to the final inUTC offset
-  const inUTC = addMilliseconds(outputInZone, -dateOffset)
+  // Note: Recalculate offset because the output may land on a different side of a DST boundary than dateInUTC
+  const outputOffset = getTimezoneOffset(tz, addMilliseconds(outputInZone, -dateOffset))
+  const inUTC = addMilliseconds(outputInZone, -outputOffset)
 
   // console.log(
   //   '[applyDate]',

--- a/src/applyDate.ts
+++ b/src/applyDate.ts
@@ -26,21 +26,19 @@ export function applyDate (
   if (isSameDay(time, date, { timezone })) return time
   const tz = timezone || 'UTC'
 
-  // Change dates from UTC to sepcified timezone
+  // Change dates from UTC to specified timezone
   const timeOffset = getTimezoneOffset(tz, time)
   const timeInZone = addMilliseconds(time, timeOffset)
   const dateOffset = getTimezoneOffset(tz, date)
   const dateInZone = addMilliseconds(date, dateOffset)
 
   // Perform the actual applying of the date
-  // Note: Order is important, year -> month -> day (otherwise funny things happen in leap years with Feb 28)
   // Note: Has to use the UTC variants to avoid interference of system timezone
+  // Note: Must set year, month, day atomically to avoid month overflow (e.g. Jan 31 -> setMonth(Feb) rolls to Mar)
   const outputInZone = new Date(timeInZone)
-  outputInZone.setUTCFullYear(dateInZone.getUTCFullYear())
-  outputInZone.setUTCMonth(dateInZone.getUTCMonth())
-  outputInZone.setUTCDate(dateInZone.getUTCDate())
+  outputInZone.setUTCFullYear(dateInZone.getUTCFullYear(), dateInZone.getUTCMonth(), dateInZone.getUTCDate())
 
-  // Change output from sepcified timezone back to UTC
+  // Change output from specified timezone back to UTC
   // Note: We guess that the dateOffset is likely identical to the final inUTC offset
   const inUTC = addMilliseconds(outputInZone, -dateOffset)
 


### PR DESCRIPTION
From our AI overlords....

setUTCFullYear, setUTCMonth, and setUTCDate were called separately. When the time argument had a day-of-month that doesn't exist in the target month, JavaScript's Date would silently overflow.

Example with your case: If time had day 31 (e.g., Jan 31 or Mar 31), then:

setUTCFullYear(2026) — fine
setUTCMonth(1) — tries to set February, but day is still 31. Feb doesn't have 31 days, so JS rolls forward to March 3.
setUTCDate(1) — sets day to 1, but month is already March → March 1 instead of February 1.
The fix: Use the single-call form setUTCFullYear(year, month, day) which applies all three atomically, avoiding intermediate overflow.